### PR TITLE
Initialize backend skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,48 @@
-# amana
+# Amana API
+
+This repository contains a minimal Express + Prisma API server for the shrine collection application described in the project specification. It defines the core database schema and provides an endpoint to query nearby shrines.
+
+## Requirements
+
+- Node.js 18+
+- PostgreSQL 15 with PostGIS
+
+Set the database connection string via `DATABASE_URL` environment variable. For example:
+
+```
+DATABASE_URL="postgresql://amana_user:amana_pass@127.0.0.1:15432/amana"
+```
+
+## Setup
+
+1. Install dependencies (network access required):
+
+```bash
+npm install
+```
+
+2. Generate Prisma client and apply migrations:
+
+```bash
+npx prisma migrate dev --name init
+```
+
+3. Seed test data:
+
+```bash
+npm run seed
+```
+
+4. Start the development server:
+
+```bash
+npm run dev
+```
+
+The API will be available at `http://localhost:3000`.
+
+## Endpoint
+
+`GET /shrines/nearby?lat=LAT&lon=LON&radius=R`
+
+Returns shrines within `radius` meters of the given coordinates.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "amana",
+  "version": "1.0.0",
+  "description": "GPS shrine collection API server",
+  "main": "dist/index.js",
+  "scripts": {
+    "build": "tsc",
+    "start": "node dist/index.js",
+    "dev": "ts-node-dev src/index.ts",
+    "seed": "ts-node prisma/seed.ts"
+  },
+  "dependencies": {
+    "express": "^4.18.2",
+    "@prisma/client": "^5.0.0"
+  },
+  "devDependencies": {
+    "@types/express": "^4.17.17",
+    "prisma": "^5.0.0",
+    "ts-node-dev": "^2.0.0",
+    "typescript": "^5.0.4"
+  },
+  "type": "module"
+}

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,0 +1,50 @@
+// Prisma schema for Amana GPS shrine collection app
+
+datasource db {
+  provider = "postgresql"
+  url      = env("DATABASE_URL")
+}
+
+generator client {
+  provider = "prisma-client-js"
+}
+
+model User {
+  id        String   @id @default(uuid())
+  name      String
+  visits    Visit[]
+  createdAt DateTime @default(now())
+}
+
+model Shrine {
+  id        Int      @id @default(autoincrement())
+  name      String
+  latitude  Float
+  longitude Float
+  deities   ShrineDeity[]
+  visits    Visit[]
+}
+
+model Deity {
+  id      Int      @id @default(autoincrement())
+  name    String
+  shrines ShrineDeity[]
+}
+
+model ShrineDeity {
+  shrine   Shrine @relation(fields: [shrineId], references: [id])
+  shrineId Int
+  deity    Deity  @relation(fields: [deityId], references: [id])
+  deityId  Int
+  @@id([shrineId, deityId])
+}
+
+model Visit {
+  id        Int      @id @default(autoincrement())
+  user      User     @relation(fields: [userId], references: [id])
+  userId    String
+  shrine    Shrine   @relation(fields: [shrineId], references: [id])
+  shrineId  Int
+  visitedAt DateTime @default(now())
+  @@index([userId, shrineId, visitedAt])
+}

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -1,0 +1,50 @@
+import { PrismaClient } from '@prisma/client'
+
+const prisma = new PrismaClient()
+
+async function main() {
+  // create users
+  const alice = await prisma.user.create({ data: { name: 'Alice' } })
+  const bob = await prisma.user.create({ data: { name: 'Bob' } })
+
+  // create deities
+  const amaterasu = await prisma.deity.create({ data: { name: 'Amaterasu' } })
+  const susanoo = await prisma.deity.create({ data: { name: 'Susanoo' } })
+
+  // create shrines
+  const shrine1 = await prisma.shrine.create({
+    data: {
+      name: 'Ise Grand Shrine',
+      latitude: 34.4594,
+      longitude: 136.7223,
+      deities: {
+        create: [{ deityId: amaterasu.id }]
+      }
+    }
+  })
+
+  const shrine2 = await prisma.shrine.create({
+    data: {
+      name: 'Izumo Taisha',
+      latitude: 35.2036,
+      longitude: 132.6853,
+      deities: {
+        create: [{ deityId: susanoo.id }]
+      }
+    }
+  })
+
+  // create visits
+  await prisma.visit.create({ data: { userId: alice.id, shrineId: shrine1.id } })
+  await prisma.visit.create({ data: { userId: bob.id, shrineId: shrine1.id } })
+  await prisma.visit.create({ data: { userId: alice.id, shrineId: shrine2.id } })
+}
+
+main()
+  .catch(e => {
+    console.error(e)
+    process.exit(1)
+  })
+  .finally(async () => {
+    await prisma.$disconnect()
+  })

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,36 @@
+import express from 'express'
+import { PrismaClient } from '@prisma/client'
+
+const prisma = new PrismaClient()
+const app = express()
+const port = process.env.PORT || 3000
+
+app.get('/shrines/nearby', async (req, res) => {
+  const lat = parseFloat(req.query.lat as string)
+  const lon = parseFloat(req.query.lon as string)
+  const radius = parseInt(req.query.radius as string) || 100
+
+  if (isNaN(lat) || isNaN(lon)) {
+    return res.status(400).json({ error: 'Invalid coordinates' })
+  }
+
+  // PostGIS distance calculation
+  const shrines = await prisma.$queryRawUnsafe<any[]>(
+    `SELECT id, name, latitude, longitude
+     FROM "Shrine"
+     WHERE ST_DWithin(
+       ST_SetSRID(ST_MakePoint(longitude, latitude), 4326)::geography,
+       ST_SetSRID(ST_MakePoint($1, $2), 4326)::geography,
+       $3
+     )`,
+    lon,
+    lat,
+    radius
+  )
+
+  res.json(shrines)
+})
+
+app.listen(port, () => {
+  console.log(`Server running on port ${port}`)
+})

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "target": "ES2019",
+    "module": "commonjs",
+    "strict": true,
+    "esModuleInterop": true,
+    "outDir": "dist",
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*.ts", "prisma/seed.ts"]
+}


### PR DESCRIPTION
## Summary
- set up a simple Express API server using TypeScript
- define Prisma database schema with User, Shrine, Deity and relation tables
- add seed script with sample data
- document setup and API usage in README

## Testing
- `npx --no-install tsc --noEmit` *(fails: Cannot find module 'express', '@prisma/client', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68441647dc48832cbd46a4b84fcb81a8