### PR TITLE
Add React Native mobile skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,3 +46,19 @@ The API will be available at `http://localhost:3000`.
 `GET /shrines/nearby?lat=LAT&lon=LON&radius=R`
 
 Returns shrines within `radius` meters of the given coordinates.
+
+## Mobile App
+
+A minimal React Native (bare workflow) project is included under `mobile/`. It uses TypeScript, React Native Paper and React Navigation to provide a bottom tab interface with placeholder screens.
+
+### Running the app
+
+Install dependencies inside the `mobile` directory and run the standard React Native commands:
+
+```bash
+cd mobile
+npm install
+npm run android   # or npm run ios
+```
+
+This will start the Metro bundler and launch the app in an emulator or device.

--- a/mobile/app.json
+++ b/mobile/app.json
@@ -1,0 +1,4 @@
+{
+  "name": "amana",
+  "displayName": "Amana"
+}

--- a/mobile/index.js
+++ b/mobile/index.js
@@ -1,0 +1,5 @@
+import { AppRegistry } from 'react-native';
+import App from './src/App';
+import { name as appName } from './app.json';
+
+AppRegistry.registerComponent(appName, () => App);

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "amana-mobile",
+  "private": true,
+  "version": "0.1.0",
+  "main": "index.js",
+  "scripts": {
+    "start": "react-native start",
+    "android": "react-native run-android",
+    "ios": "react-native run-ios"
+  },
+  "dependencies": {
+    "react": "18.2.0",
+    "react-native": "0.72.0",
+    "react-native-paper": "^5.3.0",
+    "zustand": "^4.3.6",
+    "@react-navigation/native": "^6.1.6",
+    "@react-navigation/bottom-tabs": "^6.5.7",
+    "react-native-screens": "^3.22.0",
+    "react-native-safe-area-context": "^4.5.0",
+    "@react-navigation/native-stack": "^6.9.12",
+    "maplibre-react-native": "^2.1.0"
+  },
+  "devDependencies": {
+    "typescript": "^5.0.4"
+  }
+}

--- a/mobile/src/App.tsx
+++ b/mobile/src/App.tsx
@@ -1,0 +1,25 @@
+import * as React from 'react';
+import { NavigationContainer } from '@react-navigation/native';
+import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
+import { Provider as PaperProvider } from 'react-native-paper';
+import MapScreen from './screens/MapScreen';
+import DexScreen from './screens/DexScreen';
+import UserScreen from './screens/UserScreen';
+import SettingsScreen from './screens/SettingsScreen';
+
+const Tab = createBottomTabNavigator();
+
+export default function App() {
+  return (
+    <PaperProvider>
+      <NavigationContainer>
+        <Tab.Navigator>
+          <Tab.Screen name="Map" component={MapScreen} />
+          <Tab.Screen name="Dex" component={DexScreen} />
+          <Tab.Screen name="User" component={UserScreen} />
+          <Tab.Screen name="Settings" component={SettingsScreen} />
+        </Tab.Navigator>
+      </NavigationContainer>
+    </PaperProvider>
+  );
+}

--- a/mobile/src/screens/DexScreen.tsx
+++ b/mobile/src/screens/DexScreen.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+
+export default function DexScreen() {
+  return (
+    <View style={styles.container}>
+      <Text>Dex Screen</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, alignItems: 'center', justifyContent: 'center' }
+});

--- a/mobile/src/screens/MapScreen.tsx
+++ b/mobile/src/screens/MapScreen.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import { View, StyleSheet } from 'react-native';
+import MapLibreGL from 'maplibre-react-native';
+
+export default function MapScreen() {
+  return (
+    <View style={styles.container}>
+      <MapLibreGL.MapView style={styles.map} />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1 },
+  map: { flex: 1 }
+});

--- a/mobile/src/screens/SettingsScreen.tsx
+++ b/mobile/src/screens/SettingsScreen.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+
+export default function SettingsScreen() {
+  return (
+    <View style={styles.container}>
+      <Text>Settings Screen</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, alignItems: 'center', justifyContent: 'center' }
+});

--- a/mobile/src/screens/UserScreen.tsx
+++ b/mobile/src/screens/UserScreen.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+
+export default function UserScreen() {
+  return (
+    <View style={styles.container}>
+      <Text>User Screen</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, alignItems: 'center', justifyContent: 'center' }
+});

--- a/mobile/tsconfig.json
+++ b/mobile/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "jsx": "react",
+    "lib": ["es2019"],
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "types": ["react", "react-native"],
+    "baseUrl": "./src"
+  },
+  "include": ["src/**/*.ts", "src/**/*.tsx"]
+}


### PR DESCRIPTION
## Summary
- add bare React Native project under `mobile`
- show placeholder screens for map, dex, user and settings
- document how to run the mobile app in README

## Testing
- `npm run build` *(fails: Cannot find module dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68442f7db734832c88b723a0d35f378b