### PR TITLE
Add shrine and visit endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,11 +41,12 @@ npm run dev
 
 The API will be available at `http://localhost:3000`.
 
-## Endpoint
+## Endpoints
 
-`GET /shrines/nearby?lat=LAT&lon=LON&radius=R`
-
-Returns shrines within `radius` meters of the given coordinates.
+- `GET /shrines/nearby?lat=LAT&lon=LON&radius=R` - Find shrines within `radius` meters of the given coordinates.
+- `GET /shrines` - List all shrines with their deities.
+- `POST /visits` - Record that a user visited a shrine. Body parameters: `userId`, `shrineId`.
+- `GET /users/:userId/visits` - List visits for the specified user.
 
 ## Mobile App
 

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   },
   "devDependencies": {
     "@types/express": "^4.17.17",
+    "@types/node": "^18.16.18",
     "prisma": "^5.0.0",
     "ts-node-dev": "^2.0.0",
     "typescript": "^5.0.4"

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ import { PrismaClient } from '@prisma/client'
 
 const prisma = new PrismaClient()
 const app = express()
+app.use(express.json())
 const port = process.env.PORT || 3000
 
 app.get('/shrines/nearby', async (req, res) => {
@@ -29,6 +30,41 @@ app.get('/shrines/nearby', async (req, res) => {
   )
 
   res.json(shrines)
+})
+
+app.get('/shrines', async (_req, res) => {
+  const shrines = await prisma.shrine.findMany({
+    include: { deities: { include: { deity: true } } }
+  })
+  res.json(shrines)
+})
+
+app.post('/visits', async (req, res) => {
+  const { userId, shrineId } = req.body
+  if (!userId || !shrineId) {
+    return res.status(400).json({ error: 'userId and shrineId required' })
+  }
+
+  try {
+    const visit = await prisma.visit.create({
+      data: {
+        userId,
+        shrineId: Number(shrineId)
+      }
+    })
+    res.status(201).json(visit)
+  } catch (e) {
+    res.status(400).json({ error: 'Could not record visit' })
+  }
+})
+
+app.get('/users/:userId/visits', async (req, res) => {
+  const { userId } = req.params
+  const visits = await prisma.visit.findMany({
+    where: { userId },
+    include: { shrine: true }
+  })
+  res.json(visits)
 })
 
 app.listen(port, () => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,8 @@
     "strict": true,
     "esModuleInterop": true,
     "outDir": "dist",
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "types": ["node"]
   },
   "include": ["src/**/*.ts", "prisma/seed.ts"]
 }


### PR DESCRIPTION
## Summary
- list all shrines with `GET /shrines`
- allow recording visits via `POST /visits`
- show user visits with `GET /users/:userId/visits`
- document new endpoints
- add Node type definitions

## Testing
- `npm run build` *(fails: Cannot find type definition file for 'node')*

------
https://chatgpt.com/codex/tasks/task_e_684433340750832cb9cb971639861527