### PR TITLE
Add additional API endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,12 @@ The API will be available at `http://localhost:3000`.
 
 - `GET /shrines/nearby?lat=LAT&lon=LON&radius=R` - Find shrines within `radius` meters of the given coordinates.
 - `GET /shrines` - List all shrines with their deities.
+- `GET /deities` - List all deities with the shrines they appear in.
+- `GET /users` - List all users.
+- `GET /shrines/:id` - Retrieve a single shrine with its deities.
+- `GET /deities/:id` - Retrieve a single deity with its shrines.
+- `POST /users` - Create a new user. Body parameters: `name`.
+- `GET /users/:userId` - Get details for a single user.
 - `POST /visits` - Record that a user visited a shrine. Body parameters: `userId`, `shrineId`.
 - `GET /users/:userId/visits` - List visits for the specified user.
 

--- a/dist/src/index.js
+++ b/dist/src/index.js
@@ -7,6 +7,7 @@ const express_1 = __importDefault(require("express"));
 const client_1 = require("@prisma/client");
 const prisma = new client_1.PrismaClient();
 const app = (0, express_1.default)();
+app.use(express_1.default.json());
 const port = process.env.PORT || 3000;
 app.get('/shrines/nearby', async (req, res) => {
     const lat = parseFloat(req.query.lat);
@@ -24,6 +25,87 @@ app.get('/shrines/nearby', async (req, res) => {
        $3
      )`, lon, lat, radius);
     res.json(shrines);
+});
+app.get('/shrines', async (_req, res) => {
+    const shrines = await prisma.shrine.findMany({
+        include: { deities: { include: { deity: true } } }
+    });
+    res.json(shrines);
+});
+app.get('/shrines/:id', async (req, res) => {
+    const id = Number(req.params.id);
+    if (isNaN(id)) {
+        return res.status(400).json({ error: 'Invalid shrine id' });
+    }
+    const shrine = await prisma.shrine.findUnique({
+        where: { id },
+        include: { deities: { include: { deity: true } } }
+    });
+    if (!shrine)
+        return res.status(404).json({ error: 'Shrine not found' });
+    res.json(shrine);
+});
+app.get('/deities', async (_req, res) => {
+    const deities = await prisma.deity.findMany({
+        include: { shrines: { include: { shrine: true } } }
+    });
+    res.json(deities);
+});
+app.get('/deities/:id', async (req, res) => {
+    const id = Number(req.params.id);
+    if (isNaN(id))
+        return res.status(400).json({ error: 'Invalid deity id' });
+    const deity = await prisma.deity.findUnique({
+        where: { id },
+        include: { shrines: { include: { shrine: true } } }
+    });
+    if (!deity)
+        return res.status(404).json({ error: 'Deity not found' });
+    res.json(deity);
+});
+app.get('/users', async (_req, res) => {
+    const users = await prisma.user.findMany();
+    res.json(users);
+});
+app.post('/users', async (req, res) => {
+    const { name } = req.body;
+    if (!name)
+        return res.status(400).json({ error: 'name required' });
+    const user = await prisma.user.create({ data: { name } });
+    res.status(201).json(user);
+});
+app.get('/users/:userId', async (req, res) => {
+    const { userId } = req.params;
+    const user = await prisma.user.findUnique({ where: { id: userId } });
+    if (!user)
+        return res.status(404).json({ error: 'User not found' });
+    res.json(user);
+});
+app.post('/visits', async (req, res) => {
+    const { userId, shrineId } = req.body;
+    if (!userId || !shrineId) {
+        return res.status(400).json({ error: 'userId and shrineId required' });
+    }
+    try {
+        const visit = await prisma.visit.create({
+            data: {
+                userId,
+                shrineId: Number(shrineId)
+            }
+        });
+        res.status(201).json(visit);
+    }
+    catch (e) {
+        res.status(400).json({ error: 'Could not record visit' });
+    }
+});
+app.get('/users/:userId/visits', async (req, res) => {
+    const { userId } = req.params;
+    const visits = await prisma.visit.findMany({
+        where: { userId },
+        include: { shrine: true }
+    });
+    res.json(visits);
 });
 app.listen(port, () => {
     console.log(`Server running on port ${port}`);

--- a/src/index.ts
+++ b/src/index.ts
@@ -39,6 +39,56 @@ app.get('/shrines', async (_req, res) => {
   res.json(shrines)
 })
 
+app.get('/shrines/:id', async (req, res) => {
+  const id = Number(req.params.id)
+  if (isNaN(id)) {
+    return res.status(400).json({ error: 'Invalid shrine id' })
+  }
+  const shrine = await prisma.shrine.findUnique({
+    where: { id },
+    include: { deities: { include: { deity: true } } }
+  })
+  if (!shrine) return res.status(404).json({ error: 'Shrine not found' })
+  res.json(shrine)
+})
+
+app.get('/deities', async (_req, res) => {
+  const deities = await prisma.deity.findMany({
+    include: { shrines: { include: { shrine: true } } }
+  })
+  res.json(deities)
+})
+
+app.get('/deities/:id', async (req, res) => {
+  const id = Number(req.params.id)
+  if (isNaN(id)) return res.status(400).json({ error: 'Invalid deity id' })
+  const deity = await prisma.deity.findUnique({
+    where: { id },
+    include: { shrines: { include: { shrine: true } } }
+  })
+  if (!deity) return res.status(404).json({ error: 'Deity not found' })
+  res.json(deity)
+})
+
+app.get('/users', async (_req, res) => {
+  const users = await prisma.user.findMany()
+  res.json(users)
+})
+
+app.post('/users', async (req, res) => {
+  const { name } = req.body
+  if (!name) return res.status(400).json({ error: 'name required' })
+  const user = await prisma.user.create({ data: { name } })
+  res.status(201).json(user)
+})
+
+app.get('/users/:userId', async (req, res) => {
+  const { userId } = req.params
+  const user = await prisma.user.findUnique({ where: { id: userId } })
+  if (!user) return res.status(404).json({ error: 'User not found' })
+  res.json(user)
+})
+
 app.post('/visits', async (req, res) => {
   const { userId, shrineId } = req.body
   if (!userId || !shrineId) {


### PR DESCRIPTION
## Summary
- add shrine, deity, and user detail endpoints
- allow creating users
- document new endpoints in README

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build` *(fails: Cannot find type definition file for 'node')*

------
https://chatgpt.com/codex/tasks/task_e_684447b80b00832c86b8ab630bf1fbaa