### PR TITLE
Add shrine visit ranking endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ The API will be available at `http://localhost:3000`.
 - `GET /users/:userId` - Get details for a single user.
 - `POST /visits` - Record that a user visited a shrine. Body parameters: `userId`, `shrineId`.
 - `GET /users/:userId/visits` - List visits for the specified user.
+- `GET /shrines/:id/ranking` - Get the top 5 visitors for the shrine.
 
 ## Mobile App
 

--- a/dist/src/index.js
+++ b/dist/src/index.js
@@ -63,6 +63,20 @@ app.get('/deities/:id', async (req, res) => {
         return res.status(404).json({ error: 'Deity not found' });
     res.json(deity);
 });
+app.get('/shrines/:id/ranking', async (req, res) => {
+    const id = Number(req.params.id);
+    if (isNaN(id)) {
+        return res.status(400).json({ error: 'Invalid shrine id' });
+    }
+    const ranking = await prisma.$queryRawUnsafe(`SELECT "userId", "User"."name", COUNT(*) AS count
+     FROM "Visit"
+     JOIN "User" ON "Visit"."userId" = "User"."id"
+     WHERE "Visit"."shrineId" = $1
+     GROUP BY "userId", "User"."name"
+     ORDER BY count DESC
+     LIMIT 5`, id);
+    res.json(ranking);
+});
 app.get('/users', async (_req, res) => {
     const users = await prisma.user.findMany();
     res.json(users);

--- a/src/index.ts
+++ b/src/index.ts
@@ -70,6 +70,30 @@ app.get('/deities/:id', async (req, res) => {
   res.json(deity)
 })
 
+app.get('/shrines/:id/ranking', async (req, res) => {
+  const id = Number(req.params.id)
+  if (isNaN(id)) {
+    return res.status(400).json({ error: 'Invalid shrine id' })
+  }
+
+  const ranking = await prisma.$queryRawUnsafe<{
+    userId: string
+    name: string
+    count: number
+  }[]>(
+    `SELECT "userId", "User"."name", COUNT(*) AS count
+     FROM "Visit"
+     JOIN "User" ON "Visit"."userId" = "User"."id"
+     WHERE "Visit"."shrineId" = $1
+     GROUP BY "userId", "User"."name"
+     ORDER BY count DESC
+     LIMIT 5`,
+    id
+  )
+
+  res.json(ranking)
+})
+
 app.get('/users', async (_req, res) => {
   const users = await prisma.user.findMany()
   res.json(users)


### PR DESCRIPTION
## Summary
- add new ranking endpoint for shrine visits
- document new ranking endpoint in README

## Testing
- `npm run build` *(fails: Cannot find type definition file for 'node')*

------
https://chatgpt.com/codex/tasks/task_e_6844494bfc54832cb991fe4ab2979161