### PR TITLE
Switch to rnmapbox maps

### DIFF
--- a/mobile/package.json
+++ b/mobile/package.json
@@ -18,7 +18,7 @@
     "react-native-screens": "^3.22.0",
     "react-native-safe-area-context": "^4.5.0",
     "@react-navigation/native-stack": "^6.9.12",
-    "maplibre-react-native": "^2.1.0"
+    "@rnmapbox/maps": "^10.5.0"
   },
   "devDependencies": {
     "typescript": "^5.0.4"

--- a/mobile/src/screens/MapScreen.tsx
+++ b/mobile/src/screens/MapScreen.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
 import { View, StyleSheet } from 'react-native';
-import MapLibreGL from 'maplibre-react-native';
+import MapboxGL from '@rnmapbox/maps';
 
 export default function MapScreen() {
   return (
     <View style={styles.container}>
-      <MapLibreGL.MapView style={styles.map} />
+      <MapboxGL.MapView style={styles.map} />
     </View>
   );
 }


### PR DESCRIPTION
## Summary
- switch map library to `@rnmapbox/maps`

## Testing
- `npm run build` *(fails: Cannot find type definition file for 'node')*

------
https://chatgpt.com/codex/tasks/task_e_68444e06aa64832c8cbe4bb9a84242e8