### PR TITLE
Fix Mapbox version again

### DIFF
--- a/mobile/package.json
+++ b/mobile/package.json
@@ -18,7 +18,7 @@
     "react-native-screens": "^3.22.0",
     "react-native-safe-area-context": "^4.5.0",
     "@react-navigation/native-stack": "^6.9.12",
-    "@rnmapbox/maps": "^10.5.1"
+    "@rnmapbox/maps": "^10.1.39"
   },
   "devDependencies": {
     "typescript": "^5.0.4"


### PR DESCRIPTION
## Summary
- update `@rnmapbox/maps` to `^10.1.39` in the mobile app

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm run build` *(fails: missing `@types/node`)*


------
https://chatgpt.com/codex/tasks/task_e_68444ffc96ec832c83cc2af9f0c359e8