### PR TITLE
Fix mobile setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,11 +69,17 @@ A minimal React Native (bare workflow) project is included under `mobile/`. It u
 
 ### Running the app
 
-Install dependencies inside the `mobile` directory and run the standard React Native commands:
+Install dependencies inside the `mobile` directory and run the standard React Native commands.
+If the native project folders are missing you'll need to create them first.
 
 ```bash
 cd mobile
 npm install
+# Native directories (`android` and `ios`) are not included in the repo.
+# Generate them with the React Native CLI if they don't exist.
+npx react-native init AmanaTmp --skip-install
+mv AmanaTmp/android AmanaTmp/ios .
+rm -rf AmanaTmp
 npm run android   # or npm run ios
 ```
 


### PR DESCRIPTION
## Summary
- clarify how to create missing Android and iOS folders before running the React Native commands

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684454b807a4832c8eb9132a314f101f