### PR TITLE
Update Windows Gradle cache cleanup steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,14 @@ Gradle に追加する必要があります。設定を行わない場合、
    Remove-Item -Recurse -Force $env:USERPROFILE\.gradle
    ```
 
-4. 削除できない場合は PC を再起動してから再度上記コマンドを実行します。
+4. 削除できない場合は PC を再起動してから次のコマンドを試します。
+
+   ```powershell
+   Remove-Item -LiteralPath "\\?\$env:USERPROFILE\.gradle" -Recurse -Force
+   Remove-Item -Recurse -Force $env:USERPROFILE\.gradle
+   # もしくは
+   cmd /c "rmdir /s /q \"%USERPROFILE%\\.gradle\""
+   ```
 
 `GRADLE_USER_HOME` を設定すると、キャッシュディレクトリを別の場所に変更できます。
 例:


### PR DESCRIPTION
## Summary
- document removing `.gradle` cache with `\?\` prefixed path
- include alternative `rmdir` command

## Testing
- `npm test` *(fails: Missing script)*
- `npm test` in mobile *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68452bcae440832c9885a0d445374ba8