### PR TITLE
docs: improve Gradle cache cleanup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,14 @@ Gradle に追加する必要があります。設定を行わない場合、
    cmd /c "rmdir /s /q \"%USERPROFILE%\\.gradle\""
    ```
 
+5. プロジェクトディレクトリに生成された `.gradle` フォルダーも削除します。
+
+   ```powershell
+   Remove-Item -Recurse -Force .gradle
+   # もしくは
+   cmd /c "rmdir /s /q .gradle"
+   ```
+
 `GRADLE_USER_HOME` を設定すると、キャッシュディレクトリを別の場所に変更できます。
 例:
 


### PR DESCRIPTION
## Summary
- document removing the project's `.gradle` directory

## Testing
- `npm run build` *(fails: Cannot find type definition file for 'node')*

------
https://chatgpt.com/codex/tasks/task_e_68455620b484832c9b4cf39cb0261fec