### PR TITLE
fix setup-gradle instructions

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,12 @@
+# Environment variables for Amana API
+# Set API keys if needed
+
+# PostgreSQL connection string used by Prisma and the API server
+DATABASE_URL="postgresql://amana_user:amana_pass@127.0.0.1:15432/amana"
+
+# Port number for the Express server
+PORT=3000
+
+# Mapbox Downloads Token for mobile build
+MAPBOX_DOWNLOADS_TOKEN=
+

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ DATABASE_URL="postgresql://amana_user:amana_pass@127.0.0.1:15432/amana"
 
 ## セットアップ手順
 
-1. `.env.example` を `.env` にコピーして、各変数の値を設定します。
+1. リポジトリに同梱されている `.env` を必要に応じて編集します。基本的な値はあらかじめ設定されているため、API キーなどの機密情報のみ書き換えてください。
 
 2. 依存パッケージをインストールします（ネットワークアクセスが必要です）。
 
@@ -81,18 +81,7 @@ API は `http://localhost:3000` で利用可能になります。
    ```
 
 4. Android SDK のパスを `ANDROID_HOME` または `android/local.properties` に設定し、`npx react-native doctor` で環境を確認します。
-5. `mobile/android/gradle.properties` に `MAPBOX_DOWNLOADS_TOKEN=<取得したトークン>` を追記し、`mobile/android/build.gradle` の `allprojects.repositories` に Mapbox の Maven ブロックを追加します。
-
-   ```gradle
-   maven {
-       url 'https://api.mapbox.com/downloads/v2/releases/maven'
-       authentication { basic(BasicAuthentication) }
-       credentials {
-           username = 'mapbox'
-           password = project.properties['MAPBOX_DOWNLOADS_TOKEN'] ?: ''
-       }
-   }
-   ```
+5. **プロジェクトのルートディレクトリで** `npm run setup-gradle` を実行し、Gradle 設定を自動で更新します。`.env` に `MAPBOX_DOWNLOADS_TOKEN` を記入しておくと、`mobile/android/gradle.properties` と `build.gradle` が書き換えられます。
 
 6. 必要に応じて `compileSdkVersion` と `targetSdkVersion` を `34` に更新後、Android プロジェクト (`mobile/android`) のルートで `./gradlew clean` を実行します。
 7. エミュレーターを起動するか実機を接続し、`npm run android` または `npm run ios` を実行します。
@@ -165,24 +154,12 @@ Gradle に追加する必要があります。設定を行わない場合、
 `com.mapbox.maps:android` などの依存関係を取得できずビルドが失敗します。
 
 1. [Mapbox アカウント](https://www.mapbox.com/) で **DOWNLOADS:READ** 権限付きの
-   トークンを生成し、`mobile/android/gradle.properties`（または
-   `~/.gradle/gradle.properties`）に `MAPBOX_DOWNLOADS_TOKEN=<取得したトークン>`
-   を追記します。デフォルトの Public Token では依存取得に失敗します。
-2. `mobile/android/build.gradle` の `allprojects.repositories` に次のブロックを
-   追加します。
+   トークンを生成し、`.env` の `MAPBOX_DOWNLOADS_TOKEN` に設定します。
+2. Android プロジェクト生成後に **リポジトリのルートで** `npm run setup-gradle`
+   を実行すると、`gradle.properties` と `build.gradle` に必要な設定が自動で追記
+   されます。
 
-   ```gradle
-   maven {
-       url 'https://api.mapbox.com/downloads/v2/releases/maven'
-       authentication { basic(BasicAuthentication) }
-       credentials {
-           username = 'mapbox'
-           password = project.properties['MAPBOX_DOWNLOADS_TOKEN'] ?: ''
-       }
-   }
-   ```
-
-これらの設定を行った後に `npm run android` を実行すると、Mapbox 関連の依存解決が
+これらを行ったあと `npm run android` を実行すれば、Mapbox 関連の依存解決が
 正常に行われるようになります。
 
 ### Gradle キャッシュを削除する (Windows)

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "build": "tsc",
     "start": "node dist/index.js",
     "dev": "ts-node-dev src/index.ts",
-    "seed": "ts-node prisma/seed.ts"
+    "seed": "ts-node prisma/seed.ts",
+    "setup-gradle": "node scripts/setup-gradle.js"
   },
   "dependencies": {
     "express": "^4.18.2",

--- a/scripts/setup-gradle.js
+++ b/scripts/setup-gradle.js
@@ -1,0 +1,52 @@
+const fs = require('fs');
+const path = require('path');
+
+// Load .env if present
+let envPath = path.resolve(__dirname, '../.env');
+let token = process.env.MAPBOX_DOWNLOADS_TOKEN;
+if (fs.existsSync(envPath)) {
+  const envData = fs.readFileSync(envPath, 'utf8');
+  for (const line of envData.split(/\r?\n/)) {
+    const m = line.match(/^MAPBOX_DOWNLOADS_TOKEN=(.*)$/);
+    if (m) {
+      token = m[1];
+      break;
+    }
+  }
+}
+
+if (!token) {
+  console.error('MAPBOX_DOWNLOADS_TOKEN is not set.');
+  process.exit(1);
+}
+
+const gradlePropsPath = path.resolve(__dirname, '../mobile/android/gradle.properties');
+const buildGradlePath = path.resolve(__dirname, '../mobile/android/build.gradle');
+
+if (!fs.existsSync(gradlePropsPath) || !fs.existsSync(buildGradlePath)) {
+  console.error('Android project not found. Please generate android/ folder first.');
+  process.exit(1);
+}
+
+// Update gradle.properties
+let props = fs.readFileSync(gradlePropsPath, 'utf8');
+if (!props.includes('MAPBOX_DOWNLOADS_TOKEN')) {
+  props += `\nMAPBOX_DOWNLOADS_TOKEN=${token}\n`;
+} else {
+  props = props.replace(/MAPBOX_DOWNLOADS_TOKEN=.*/g, `MAPBOX_DOWNLOADS_TOKEN=${token}`);
+}
+fs.writeFileSync(gradlePropsPath, props);
+console.log('Updated gradle.properties');
+
+// Insert Mapbox Maven block if missing
+let buildGradle = fs.readFileSync(buildGradlePath, 'utf8');
+const repoBlock = `maven {\n        url 'https://api.mapbox.com/downloads/v2/releases/maven'\n        authentication { basic(BasicAuthentication) }\n        credentials {\n            username = 'mapbox'\n            password = project.properties['MAPBOX_DOWNLOADS_TOKEN'] ?: ''\n        }\n    }`;
+
+if (!buildGradle.includes("api.mapbox.com")) {
+  buildGradle = buildGradle.replace(/allprojects\s*\{\n\s*repositories \{/, match => match + `\n        ${repoBlock.replace(/\n/g, '\n        ')}`);
+  fs.writeFileSync(buildGradlePath, buildGradle);
+  console.log('Inserted Mapbox repository block');
+} else {
+  console.log('Mapbox repository block already present');
+}
+


### PR DESCRIPTION
## Summary
- add default .env file so only API keys need editing
- clarify gradle setup instructions
- provide script to update `gradle.properties` and `build.gradle`

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6845710bb038832cacfe85de64030984