### PR TITLE
Add Android update script and improve README

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,11 +90,15 @@ Remove-Item -Recurse -Force AmanaTmp
    設定を自動で更新します。`.env` に `MAPBOX_DOWNLOADS_TOKEN` を記入しておくと、
    `mobile/android/gradle.properties` と `build.gradle` が書き換えられます。
 
-6. ビルドエラーが発生する場合は `mobile/android/build.gradle` を開き、
-   `compileSdkVersion` と `targetSdkVersion` を **34** に更新します。
+6. Android SDK と Gradle 周りの設定を自動調整するために、続けて
+   `npm run update-android-sdk` を実行します。これにより
+   `compileSdkVersion` と `targetSdkVersion` が **34** に更新され、
+   Gradle 8.1.1 および Android Gradle Plugin 8.1.2 を使用するよう
+   `gradle-wrapper.properties` や `build.gradle` が書き換えられます。
    変更後は Android プロジェクト (`mobile/android`) のルートで
    `./gradlew clean`（Windows では `\.\gradlew.bat clean`）を実行してください。
    詳細は後述の「Android API レベルの更新」節も参照します。
+
 7. エミュレーターを起動するか実機を接続し、`npm run android` または `npm run ios` を実行します。
 
 ### アプリの実行方法
@@ -201,23 +205,16 @@ $env:GRADLE_USER_HOME = "D:\\gradle-cache"
 これは依存ライブラリが **Android API 34** 以上でのビルドを要求しているためです。
 
 `npx react-native init` で生成した直後のプロジェクトでは `compileSdkVersion`
-および `targetSdkVersion` が `33` になっているので、次のように
-`mobile/android/build.gradle` の設定を更新してください。
+および `targetSdkVersion` が `33` になっているため、そのままでは依存ライブラリが
+要求する API レベルと一致せずビルドに失敗します。
 
-```gradle
-android {
-    compileSdkVersion = 34
+本リポジトリでは `npm run update-android-sdk` を用意しており、実行すると
+`compileSdkVersion` と `targetSdkVersion` を **34** に変更するとともに、
+Gradle ラッパーと Android Gradle Plugin を推奨バージョンに更新します。
 
-    defaultConfig {
-        targetSdkVersion = 34
-        // その他の設定
-    }
-}
-```
-
-変更後に Android プロジェクト (`mobile/android`) のルートで `./gradlew clean` (Windows では `\.\gradlew.bat clean`) を実行し、
-改めて `npm run android` を実行することで
-ビルドが通るようになります。
+スクリプト実行後は Android プロジェクト (`mobile/android`) のルートで
+`./gradlew clean` (Windows では `\.\gradlew.bat clean`) を実行し、
+改めて `npm run android` を実行してください。
 
 ### Kotlin コンパイルエラーが出る場合
 

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "start": "node dist/index.js",
     "dev": "ts-node-dev src/index.ts",
     "seed": "ts-node prisma/seed.ts",
-    "setup-gradle": "node scripts/setup-gradle.js"
+    "setup-gradle": "node scripts/setup-gradle.js",
+    "update-android-sdk": "node scripts/update-android-sdk.js"
   },
   "dependencies": {
     "express": "^4.18.2",

--- a/scripts/update-android-sdk.js
+++ b/scripts/update-android-sdk.js
@@ -1,0 +1,42 @@
+const fs = require('fs');
+const path = require('path');
+
+const androidDir = path.resolve(__dirname, '../mobile/android');
+const wrapperProp = path.join(androidDir, 'gradle/wrapper/gradle-wrapper.properties');
+const buildGradle = path.join(androidDir, 'build.gradle');
+const projectBuildGradle = path.join(androidDir, 'app', 'build.gradle');
+
+if (!fs.existsSync(androidDir)) {
+  console.error('android directory not found. Run react-native init first.');
+  process.exit(1);
+}
+
+// Update gradle wrapper
+if (fs.existsSync(wrapperProp)) {
+  let data = fs.readFileSync(wrapperProp, 'utf8');
+  data = data.replace(/distributionUrl=.*gradle-.*-all.zip/,
+    'distributionUrl=https\://services.gradle.org/distributions/gradle-8.1.1-all.zip');
+  fs.writeFileSync(wrapperProp, data);
+  console.log('Updated gradle wrapper to 8.1.1');
+}
+
+// Update Android Gradle plugin
+if (fs.existsSync(buildGradle)) {
+  let data = fs.readFileSync(buildGradle, 'utf8');
+  data = data.replace(/com.android.tools.build:gradle:\d+\.\d+\.\d+/,
+    'com.android.tools.build:gradle:8.1.2');
+  fs.writeFileSync(buildGradle, data);
+  console.log('Updated Android Gradle plugin');
+}
+
+// Update compileSdkVersion and targetSdkVersion
+if (fs.existsSync(projectBuildGradle)) {
+  let data = fs.readFileSync(projectBuildGradle, 'utf8');
+  data = data.replace(/compileSdkVersion\s*=?\s*\d+/g, 'compileSdkVersion = 34');
+  data = data.replace(/targetSdkVersion\s*=?\s*\d+/g, 'targetSdkVersion = 34');
+  fs.writeFileSync(projectBuildGradle, data);
+  console.log('Updated compileSdkVersion and targetSdkVersion to 34');
+}
+
+console.log('Android configuration updated. Run ./gradlew clean to apply changes.');
+


### PR DESCRIPTION
## Summary
- add `update-android-sdk` script for upgrading Gradle and SDK versions
- document mobile setup steps using the new script

## Testing
- `node scripts/update-android-sdk.js` (shows message when android folder missing)

------
https://chatgpt.com/codex/tasks/task_e_684e46e0ba5c832cbff218daed08ec16