### PR TITLE
Fix Android build automation

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,8 @@ Remove-Item -Recurse -Force AmanaTmp
    詳細は後述の「Android API レベルの更新」節も参照します。
 
 7. エミュレーターを起動するか実機を接続し、`npm run android` または `npm run ios` を実行します。
+   `npm run android` は内部で `npm run update-android-sdk` を呼び出し、
+   `compileSdkVersion` と `targetSdkVersion` を自動で最新に更新します。
 
 ### アプリの実行方法
 初回セットアップ後は、次のコマンドでアプリを起動できます。`android` と `ios`

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "start": "react-native start",
-    "android": "react-native run-android",
+    "android": "node ../scripts/update-android-sdk.js && react-native run-android",
     "ios": "react-native run-ios"
   },
   "dependencies": {


### PR DESCRIPTION
## Summary
- run the update-android-sdk script automatically before `react-native run-android`
- document automatic SDK updates in the setup guide

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684e788c7d54832c937611368534a4f3