### PR TITLE
Fix gradle plugin setup docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,8 @@ Remove-Item -Recurse -Force AmanaTmp
    `gradle-wrapper.properties` や `build.gradle` が書き換えられます。
    変更後は Android プロジェクト (`mobile/android`) のルートで
    `./gradlew clean`（Windows では `\.\gradlew.bat clean`）を実行してください。
+   `node_modules` が無い場合は `cd mobile` して `npm install` を行い、
+   `react-native-gradle-plugin` をインストールしてから再度実行します。
    詳細は後述の「Android API レベルの更新」節も参照します。
 
 7. エミュレーターを起動するか実機を接続し、`npm run android` または `npm run ios` を実行します。

--- a/scripts/update-android-sdk.js
+++ b/scripts/update-android-sdk.js
@@ -5,6 +5,7 @@ const androidDir = path.resolve(__dirname, '../mobile/android');
 const wrapperProp = path.join(androidDir, 'gradle/wrapper/gradle-wrapper.properties');
 const buildGradle = path.join(androidDir, 'build.gradle');
 const appBuildGradle = path.join(androidDir, 'app', 'build.gradle');
+const pluginDir = path.resolve(__dirname, '../mobile/node_modules/react-native-gradle-plugin');
 
 if (!fs.existsSync(androidDir)) {
   console.error('android directory not found. Run react-native init first.');
@@ -41,4 +42,10 @@ if (fs.existsSync(appBuildGradle)) {
 }
 
 console.log('Android configuration updated. Run ./gradlew clean to apply changes.');
+
+if (!fs.existsSync(pluginDir)) {
+  console.warn(
+    'react-native-gradle-plugin not found. Run "npm install" in the mobile/ directory before executing gradle tasks.'
+  );
+}
 


### PR DESCRIPTION
## Summary
- warn to reinstall `node_modules` before running Gradle
- add plugin presence check in `update-android-sdk.js`

## Testing
- `npm run build`
- `node scripts/update-android-sdk.js` *(fails: android directory not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ea237b61c832cb304376ebd3ff051