### PR TITLE
Update README for JDK 17 and enable BuildConfig

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,10 @@ npm install react-native-screens@4.11.1
 npm install react-native-gradle-plugin
 cd $env:GITHUB_REPOS_DIR\amana
 npm run update-android-sdk  # Kotlin バージョンも自動で調整されます
+# build.gradle に buildFeatures.buildConfig true を自動で追加します
 cd $env:GITHUB_REPOS_DIR\amana\mobile\android
+# JDK17 を利用するよう JAVA_HOME を設定してください
+$env:JAVA_HOME = "C:\\path\\to\\jdk17"
 .\gradlew.bat clean
 npx react-native doctor
 npm run android   # または npm run ios

--- a/scripts/update-android-sdk.js
+++ b/scripts/update-android-sdk.js
@@ -38,6 +38,17 @@ if (fs.existsSync(appBuildGradle)) {
   let data = fs.readFileSync(appBuildGradle, 'utf8');
   data = data.replace(/compileSdkVersion\s*=?\s*\d+/g, 'compileSdkVersion = 34');
   data = data.replace(/targetSdkVersion\s*=?\s*\d+/g, 'targetSdkVersion = 34');
+  if (/buildFeatures/.test(data)) {
+    data = data.replace(/buildFeatures\s*\{[^}]*\}/s, (m) => {
+      return /buildConfig\s+true/.test(m)
+        ? m
+        : m.replace(/\}/, '    buildConfig true\n    }');
+    });
+  } else {
+    data = data.replace(/android\s*\{/, (m) =>
+      `${m}\n    buildFeatures {\n        buildConfig true\n    }`
+    );
+  }
   fs.writeFileSync(appBuildGradle, data);
   console.log('Updated compileSdkVersion and targetSdkVersion to 34 in app/build.gradle');
 }


### PR DESCRIPTION
## Summary
- mention that `update-android-sdk` now adds `buildFeatures.buildConfig true`
- note that Gradle requires JDK 17 and show setting `JAVA_HOME`
- auto-enable `buildFeatures.buildConfig` in `update-android-sdk.js`

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684eb81bcd64832cac254ff8a74bf294