### PR TITLE
Update android guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,8 @@ npm run update-android-sdk  # Kotlin バージョンも自動で調整されま�
 #   `gradle.properties` に `org.gradle.java.home` を追記します。
 cd $env:GITHUB_REPOS_DIR\amana\mobile\android
 .\gradlew.bat clean
+# もし上記で再び `compileSdkVersion is not specified` などと表示された場合は
+# もう一度 `npm run update-android-sdk` を実行してから再試行してください。
 npx react-native doctor
 npm run android   # または npm run ios
 ```

--- a/scripts/update-android-sdk.js
+++ b/scripts/update-android-sdk.js
@@ -66,8 +66,16 @@ if (fs.existsSync(buildGradle)) {
   let data = fs.readFileSync(buildGradle, 'utf8');
   data = data.replace(/com.android.tools.build:gradle:\d+\.\d+\.\d+/, 'com.android.tools.build:gradle:8.1.2');
   data = data.replace(/buildToolsVersion\s*=\s*"[\d.]+"/, 'buildToolsVersion = "34.0.0"');
-  data = data.replace(/compileSdkVersion\s*=\s*\d+/, 'compileSdkVersion = 34');
-  data = data.replace(/targetSdkVersion\s*=\s*\d+/, 'targetSdkVersion = 34');
+  if (/compileSdkVersion/.test(data)) {
+    data = data.replace(/compileSdkVersion\s*=\s*\d+/, 'compileSdkVersion = 34');
+  } else {
+    data = data.replace(/android\s*\{/, '$&\n    compileSdkVersion = 34');
+  }
+  if (/targetSdkVersion/.test(data)) {
+    data = data.replace(/targetSdkVersion\s*=\s*\d+/, 'targetSdkVersion = 34');
+  } else {
+    data = data.replace(/android\s*\{/, '$&\n    targetSdkVersion = 34');
+  }
   fs.writeFileSync(buildGradle, data);
   console.log('Updated Android Gradle plugin and SDK versions');
 }
@@ -75,8 +83,16 @@ if (fs.existsSync(buildGradle)) {
 // Update compileSdkVersion and targetSdkVersion in app/build.gradle for older templates
 if (fs.existsSync(appBuildGradle)) {
   let data = fs.readFileSync(appBuildGradle, 'utf8');
-  data = data.replace(/compileSdkVersion\s*=?\s*\d+/g, 'compileSdkVersion = 34');
-  data = data.replace(/targetSdkVersion\s*=?\s*\d+/g, 'targetSdkVersion = 34');
+  if (/compileSdkVersion/.test(data)) {
+    data = data.replace(/compileSdkVersion\s*=?\s*(\d+|[A-Za-z_.]+)/g, 'compileSdkVersion = 34');
+  } else {
+    data = data.replace(/android\s*\{/, '$&\n    compileSdkVersion = 34');
+  }
+  if (/targetSdkVersion/.test(data)) {
+    data = data.replace(/targetSdkVersion\s*=?\s*(\d+|[A-Za-z_.]+)/g, 'targetSdkVersion = 34');
+  } else {
+    data = data.replace(/android\s*\{/, '$&\n    targetSdkVersion = 34');
+  }
   if (/buildFeatures/.test(data)) {
     data = data.replace(/buildFeatures\s*\{[^}]*\}/s, (m) => {
       return /buildConfig\s+true/.test(m)


### PR DESCRIPTION
## Summary
- handle missing SDK versions in update-android-sdk script
- clarify README about rerunning update-android-sdk when gradle fails

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684f05014e7c832c8db8613fe9c00d1d