### PR TITLE
Update README and scripts for stable RN setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,11 @@ APIサーバーはコアとなるデータベーススキーマを定義し、�
 
 - Node.js 18 以上
 - PostgreSQL 15 （PostGIS 拡張付き）
+- JDK 11
+- Android NDK 23.1
+
+推奨バージョン構成: React Native 0.71.8 + @rnmapbox/maps 10.5.0 + Prisma v5
+現行の React Native 0.72.x は安定版リリース前で不具合が報告されています。Mapbox を利用する場合は 0.71 系を推奨します。
 
 サーバーは CommonJS モジュールとして構成されており、`npm run dev` を実行すると `ts-node-dev` を介して起動します。
 
@@ -22,7 +27,7 @@ DATABASE_URL="postgresql://amana_user:amana_pass@127.0.0.1:15432/amana"
 ```powershell
 # 環境準備
 $env:GITHUB_REPOS_DIR=GitHubローカルリポジトリのルートディレクトリ
-$env:JAVA_HOME=JDK17のインストールフォルダ
+$env:JAVA_HOME=JDK11のインストールフォルダ
 
 # リポジトリ取得
 cd $env:GITHUB_REPOS_DIR
@@ -57,7 +62,7 @@ npm run update-android-sdk  # Kotlin バージョンも自動で調整されま�
 #   `compileSdkVersion is not specified` や
 #   `Could not find method kotlinOptions()`
 #   といったエラーが発生します。
-#   実行時に Java 17 以上がインストールされているかを確認し、
+#   実行時に Java 11 以上がインストールされているかを確認し、
 #   足りない場合はエラーを表示します。
 #   `JAVA_HOME` が設定されている場合は
 #   `gradle.properties` に `org.gradle.java.home` を追記します。
@@ -74,7 +79,7 @@ npm run android   # または npm run ios
 
 ### Android ビルドメモ
 
-- JDK 17 を利用してください。
+- JDK 11 を利用してください。
 - ビルドに失敗したら `npm run update-android-sdk` と
   `./gradlew.bat clean` を試してください。
 
@@ -143,7 +148,7 @@ API は `http://localhost:3000` で利用可能になります。
 3. `android` と `ios` フォルダーが無い場合は次のコマンドで生成して配置します。
 
 ```powershell
-npx react-native init AmanaTmp --template react-native@0.72.7
+npx react-native init AmanaTmp --template react-native@0.71.8
 Move-Item AmanaTmp/android ./android -Force
 Move-Item AmanaTmp/ios ./ios -Force
 Remove-Item -Recurse -Force AmanaTmp
@@ -282,7 +287,7 @@ $env:GRADLE_USER_HOME = "D:\\gradle-cache"
 本リポジトリでは `npm run update-android-sdk` を用意しており、実行すると
 `compileSdkVersion` と `targetSdkVersion` を **34** に変更するとともに、
 Gradle ラッパーと Android Gradle Plugin を推奨バージョンに更新します。
-また、Java 17 がインストールされているかをチェックし、
+また、Java 11 がインストールされているかをチェックし、
 不足している場合はエラーを表示します。
 `JAVA_HOME` が指定されている場合は `gradle.properties` の
 `org.gradle.java.home` を自動で設定します。

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "react": "18.2.0",
-    "react-native": "0.72.0",
+    "react-native": "0.71.8",
     "react-native-paper": "^5.3.0",
     "zustand": "^4.3.6",
     "@react-navigation/native": "^6.1.6",
@@ -18,9 +18,9 @@
     "react-native-screens": "^4.11.1",
     "react-native-safe-area-context": "^4.5.0",
     "@react-navigation/native-stack": "^6.9.12",
-    "@rnmapbox/maps": "^10.1.39"
+    "@rnmapbox/maps": "10.5.0"
   },
   "devDependencies": {
-    "typescript": "^5.0.4"
+    "typescript": "^5.3.3"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,14 +8,15 @@
       "name": "amana",
       "version": "1.0.0",
       "dependencies": {
-        "@prisma/client": "^5.0.0",
+        "@prisma/client": "^5.13.0",
         "express": "^4.18.2"
       },
       "devDependencies": {
         "@types/express": "^4.17.17",
-        "prisma": "^5.0.0",
+        "@types/node": "^18.16.18",
+        "prisma": "^5.13.0",
         "ts-node-dev": "^2.0.0",
-        "typescript": "^5.0.4"
+        "typescript": "^5.3.3"
       }
     },
     "node_modules/@cspotcode/source-map-support": {
@@ -217,13 +218,13 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "22.15.30",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.15.30.tgz",
-      "integrity": "sha512-6Q7lr06bEHdlfplU6YRbgG1SFBdlsfNC4/lX+SkhiTs0cpJkOElmWls8PxDFv4yY/xKb8Y6SO0OmSX4wgqTZbA==",
+      "version": "18.19.112",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.112.tgz",
+      "integrity": "sha512-i+Vukt9POdS/MBI7YrrkkI5fMfwFtOjphSmt4WXYLfwqsfr6z/HdCx7LqT9M7JktGob8WNgj8nFB4TbGNE4Cog==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~6.21.0"
+        "undici-types": "~5.26.4"
       }
     },
     "node_modules/@types/qs": {
@@ -1713,9 +1714,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
-      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -13,14 +13,14 @@
   },
   "dependencies": {
     "express": "^4.18.2",
-    "@prisma/client": "^5.0.0"
+    "@prisma/client": "^5.13.0"
   },
   "devDependencies": {
     "@types/express": "^4.17.17",
     "@types/node": "^18.16.18",
-    "prisma": "^5.0.0",
+    "prisma": "^5.13.0",
     "ts-node-dev": "^2.0.0",
-    "typescript": "^5.0.4"
+    "typescript": "^5.3.3"
   },
   "type": "commonjs"
 }

--- a/scripts/update-android-sdk.js
+++ b/scripts/update-android-sdk.js
@@ -20,12 +20,12 @@ let javaVersionOut;
 try {
   javaVersionOut = execSync('java -version 2>&1', { encoding: 'utf8' });
 } catch (e) {
-  console.error('Java not found. Please install JDK 17 and set JAVA_HOME.');
+  console.error('Java not found. Please install JDK 11 and set JAVA_HOME.');
   process.exit(1);
 }
 const match = javaVersionOut.match(/version "(\d+)/);
-if (!match || parseInt(match[1], 10) < 17) {
-  console.error('JDK 17 or newer is required. Current java -version output:\n' + javaVersionOut);
+if (!match || parseInt(match[1], 10) < 11) {
+  console.error('JDK 11 or newer is required. Current java -version output:\n' + javaVersionOut);
   process.exit(1);
 }
 
@@ -48,7 +48,7 @@ if (fs.existsSync(gradleProperties)) {
     fs.writeFileSync(gradleProperties, props);
     console.log('Updated org.gradle.java.home in gradle.properties');
   } else {
-    console.warn('JAVA_HOME が設定されていません。JDK 17 のパスを指定してください。');
+    console.warn('JAVA_HOME が設定されていません。JDK 11 のパスを指定してください。');
   }
 }
 
@@ -106,19 +106,19 @@ if (fs.existsSync(appBuildGradle)) {
   }
   if (/compileOptions/.test(data)) {
     data = data.replace(/sourceCompatibility\s+JavaVersion\.VERSION_\d+/,
-      'sourceCompatibility JavaVersion.VERSION_17');
+      'sourceCompatibility JavaVersion.VERSION_11');
     data = data.replace(/targetCompatibility\s+JavaVersion\.VERSION_\d+/,
-      'targetCompatibility JavaVersion.VERSION_17');
+      'targetCompatibility JavaVersion.VERSION_11');
   } else {
     data = data.replace(/android\s*\{/, (m) =>
-      `${m}\n    compileOptions {\n        sourceCompatibility JavaVersion.VERSION_17\n        targetCompatibility JavaVersion.VERSION_17\n    }`);
+      `${m}\n    compileOptions {\n        sourceCompatibility JavaVersion.VERSION_11\n        targetCompatibility JavaVersion.VERSION_11\n    }`);
   }
   if (/kotlinOptions/.test(data)) {
     data = data.replace(/jvmTarget\s*=\s*"?\d+"?/,
-      'jvmTarget = "17"');
+      'jvmTarget = "11"');
   } else {
     data = data.replace(/android\s*\{/, (m) =>
-      `${m}\n    kotlinOptions {\n        jvmTarget = "17"\n    }`);
+      `${m}\n    kotlinOptions {\n        jvmTarget = "11"\n    }`);
   }
   fs.writeFileSync(appBuildGradle, data);
   console.log('Updated compileSdkVersion and targetSdkVersion to 34 in app/build.gradle');


### PR DESCRIPTION
## Summary
- document recommended React Native and Mapbox versions
- align API server dependencies with Prisma v5
- pin React Native 0.71.8 and Mapbox 10.5.0 in mobile package
- require JDK 11 in update-android-sdk.js
- adjust README instructions for JDK 11

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6850310b2edc832cb99e3cd19f923a19