### PR TITLE
fix: setup-gradle fallback for settings file

### DIFF
--- a/scripts/setup-gradle.js
+++ b/scripts/setup-gradle.js
@@ -88,7 +88,17 @@ if (fs.existsSync(settingsGradlePath)) {
       fs.writeFileSync(settingsGradlePath, settingsGradle);
       console.log('Inserted Mapbox repository block into settings.gradle');
     } else {
-      console.warn('Could not find repository block in settings.gradle');
+      settingsGradle +=
+        '\n' +
+        'dependencyResolutionManagement {\n' +
+        '    repositories {\n' +
+        formatted +
+        '\n    }\n' +
+        '}\n';
+      fs.writeFileSync(settingsGradlePath, settingsGradle);
+      console.log(
+        'Added dependencyResolutionManagement block with Mapbox repository to settings.gradle'
+      );
     }
   } else {
     console.log('Mapbox repository block already present in settings.gradle');


### PR DESCRIPTION
## Summary
- insert Mapbox repo into settings.gradle even when repository block is missing

## Testing
- `npm run setup-gradle --silent` (with dummy android project)

------
https://chatgpt.com/codex/tasks/task_e_685753da7648832cb9c44ec830886a4e