### PR TITLE
Add debug logging for compileSdk check

### DIFF
--- a/scripts/update-android-sdk.js
+++ b/scripts/update-android-sdk.js
@@ -291,21 +291,26 @@ if (fs.existsSync(rnmapboxGradle)) {
 
 // Final sanity check
 if (fs.existsSync(appBuildGradle)) {
+  const debug = process.env.DEBUG_SDK_UPDATE;
   const finalData = fs.readFileSync(appBuildGradle, 'utf8');
   let compileSdkOK =
     /compileSdk(?:Version)?\s*=?\s*34/.test(finalData) ||
     /compileSdk\s*=?\s*34/.test(finalData);
-  if (
-    !compileSdkOK &&
-    /compileSdk(?:Version)?\s*=?.*ext.*compileSdk(?:Version)?/.test(finalData)
-  ) {
-    if (fs.existsSync(buildGradle)) {
-      const rootData = fs.readFileSync(buildGradle, 'utf8');
-      compileSdkOK =
-        /compileSdk(?:Version)?\s*=\s*34/.test(rootData) ||
-        /compileSdk\s*=\s*34/.test(rootData) ||
-        /ext.*compileSdk(?:Version)?\s*=\s*34/.test(rootData);
+  if (!compileSdkOK && fs.existsSync(buildGradle)) {
+    const rootData = fs.readFileSync(buildGradle, 'utf8');
+    if (debug) {
+      const lines = rootData.match(/^.*compileSdk.*$/gm);
+      console.log('[DEBUG] root build.gradle compileSdk lines:\n' + (lines ? lines.join('\n') : 'none'));
     }
+    compileSdkOK =
+      /compileSdk(?:Version)?\s*=\s*34/.test(rootData) ||
+      /compileSdk\s*=\s*34/.test(rootData) ||
+      /ext[\s\S]*compileSdk(?:Version)?\s*=\s*34/.test(rootData);
+  }
+  if (debug) {
+    const lines = finalData.match(/^.*compileSdk.*$/gm);
+    console.log('[DEBUG] app/build.gradle compileSdk lines:\n' + (lines ? lines.join('\n') : 'none'));
+    console.log('[DEBUG] compileSdkOK:', compileSdkOK);
   }
   if (!compileSdkOK) {
     console.warn(


### PR DESCRIPTION
## Summary
- provide optional DEBUG_SDK_UPDATE logs to inspect compileSdk lines
- improve compileSdk check to always inspect root build.gradle if needed

## Testing
- `node --check scripts/update-android-sdk.js`


------
https://chatgpt.com/codex/tasks/task_e_6857753f1ad4832cbe95d70a33b1a2dd