### PR TITLE
Fix mobile build dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ cd $env:GITHUB_REPOS_DIR\amana
 npm run init-mobile        # 初回のみ
 cd $env:GITHUB_REPOS_DIR\amana\mobile
 npm install
+# 依存パッケージは react-native-screens 3.22.0,
+# @rnmapbox/maps 10.1.32 に固定済み
 npm audit fix --force
 cd $env:GITHUB_REPOS_DIR\amana
 # .env の MAPBOX_DOWNLOADS_TOKEN を設定

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -15,10 +15,10 @@
     "zustand": "^4.3.6",
     "@react-navigation/native": "^6.1.6",
     "@react-navigation/bottom-tabs": "^6.5.7",
-    "react-native-screens": "^4.11.1",
+    "react-native-screens": "3.22.0",
     "react-native-safe-area-context": "^4.5.0",
     "@react-navigation/native-stack": "^6.9.12",
-    "@rnmapbox/maps": "10.1.39"
+    "@rnmapbox/maps": "10.1.32"
   },
   "devDependencies": {
     "typescript": "^5.3.3"


### PR DESCRIPTION
## Summary
- pin mobile dependency versions for react-native-screens and rnmapbox
- note the pinned versions in the quick start

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6857b9e08fc0832ca3bdf5a22a2e580d