### PR TITLE
Add buildConfig patch for modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,8 @@ cd $env:GITHUB_REPOS_DIR\amana
 npm run setup-gradle
 cd $env:GITHUB_REPOS_DIR\amana
 $env:ANDROID_PACKAGE_NAME = 'jp.kmaruoka.amana'
-npm run update-android-sdk
+npm run update-android-sdk  # 依存モジュールの BuildConfig も有効化します
+# 新しい依存パッケージをインストールした後は再実行してください
 cd $env:GITHUB_REPOS_DIR\amana\mobile\android
 .\gradlew.bat clean
 # android フォルダがロックされる場合は Gradle デーモンを停止
@@ -48,3 +49,23 @@ npx react-native doctor
 npm run android   # または npm run ios
 ```
 
+## エラー時のリスタート手順
+
+ビルドエラーなどで `android` フォルダがロックされ、クリーンアップに失敗する場合は次の手順で環境をリセットしてください。
+
+```powershell
+# エミュレータを終了
+adb emu kill
+
+# Gradle デーモンを停止してロックを解除
+cd $env:GITHUB_REPOS_DIR\amana\mobile\android
+.\gradlew.bat --stop
+
+# リポジトリをクリーンな状態に戻す
+cd $env:GITHUB_REPOS_DIR\amana
+git reset --hard
+git clean -fdx
+git pull
+```
+
+その後、上記 Quick Start の "モバイルセットアップ" 以降のコマンドを再実行します。

--- a/scripts/update-android-sdk.js
+++ b/scripts/update-android-sdk.js
@@ -42,6 +42,27 @@ function updateModuleCompileOptions(gradlePath) {
   }
 }
 
+function updateModuleBuildFeatures(gradlePath) {
+  if (!fs.existsSync(gradlePath)) return;
+  let data = fs.readFileSync(gradlePath, 'utf8');
+  let changed = false;
+  if (/android\s*\{/.test(data)) {
+    if (/buildFeatures/.test(data)) {
+      if (!/buildConfig\s+true/.test(data)) {
+        data = data.replace(/buildFeatures\s*\{/, '$&\n        buildConfig true');
+        changed = true;
+      }
+    } else {
+      data = data.replace(/android\s*\{/, (m) => `${m}\n    buildFeatures {\n        buildConfig true\n    }`);
+      changed = true;
+    }
+  }
+  if (changed) {
+    fs.writeFileSync(gradlePath, data);
+    console.log(`Enabled buildConfig in ${path.basename(path.dirname(gradlePath))}`);
+  }
+}
+
 // Resolve package name for Android namespace
 let packageName = process.env.ANDROID_PACKAGE_NAME;
 if (!packageName && fs.existsSync(appJsonPath)) {
@@ -337,6 +358,7 @@ if (fs.existsSync(nodeModulesDir)) {
   for (const mod of modules) {
     const g = path.join(nodeModulesDir, mod, 'android', 'build.gradle');
     updateModuleCompileOptions(g);
+    updateModuleBuildFeatures(g);
   }
 }
 


### PR DESCRIPTION
## Summary
- document that `npm run update-android-sdk` enables BuildConfig
- patch `update-android-sdk.js` so it also enables BuildConfig for `react-native-screens` and `react-native-safe-area-context`
- note in README that the update script should be rerun after installing packages

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6857bbcaa6c8832cb5f61b2e529c54a4