### PR TITLE
Patch react-native-screens for new SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,8 @@ cd $env:GITHUB_REPOS_DIR\amana
 npm run setup-gradle
 cd $env:GITHUB_REPOS_DIR\amana
 $env:ANDROID_PACKAGE_NAME = 'jp.kmaruoka.amana'
-npm run update-android-sdk
+npm run update-android-sdk  # 依存モジュールの BuildConfig と react-native-screens 用パッチを適用
+# 新しい依存パッケージをインストールした後は再実行してください
 cd $env:GITHUB_REPOS_DIR\amana\mobile\android
 .\gradlew.bat clean
 # android フォルダがロックされる場合は Gradle デーモンを停止
@@ -48,3 +49,23 @@ npx react-native doctor
 npm run android   # または npm run ios
 ```
 
+## エラー時のリスタート手順
+
+ビルドエラーなどで `android` フォルダがロックされ、クリーンアップに失敗する場合は次の手順で環境をリセットしてください。
+
+```powershell
+# エミュレータを終了
+adb emu kill
+
+# Gradle デーモンを停止してロックを解除
+cd $env:GITHUB_REPOS_DIR\amana\mobile\android
+.\gradlew.bat --stop
+
+# リポジトリをクリーンな状態に戻す
+cd $env:GITHUB_REPOS_DIR\amana
+git reset --hard
+git clean -fdx
+git pull
+```
+
+その後、上記 Quick Start の "モバイルセットアップ" 以降のコマンドを再実行します。


### PR DESCRIPTION
## Summary
- patch `update-android-sdk.js` to fix `react-native-screens` when using newer SDKs
- document that `update-android-sdk` also patches `react-native-screens`

## Testing
- `npm install`
- `npm run build`
- `npm run android` *(fails: android directory not found)*

------
https://chatgpt.com/codex/tasks/task_e_6857bbcaa6c8832cb5f61b2e529c54a4