### PR TITLE
Fix build script and update requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,9 @@
 
 - Node.js 18 以上
 - JDK 17 以上
+- Android SDK Build-Tools 36
+- Android SDK Command-line Tools (latest)
+- Android SDK Platform-Tools
 
 ## Quick Start
 

--- a/scripts/update-android-sdk.js
+++ b/scripts/update-android-sdk.js
@@ -376,13 +376,13 @@ if (fs.existsSync(nodeModulesDir)) {
   );
   if (fs.existsSync(screensKt)) {
     let ktData = fs.readFileSync(screensKt, 'utf8');
-    if (/R\.attr\.colorPrimary/.test(ktData)) {
+    if (/androidx\.appcompat\.R\.attr\.colorPrimary/.test(ktData)) {
       ktData = ktData.replace(
-        /R\.attr\.colorPrimary/g,
-        'androidx.appcompat.R.attr.colorPrimary',
+        /androidx\.appcompat\.R\.attr\.colorPrimary/g,
+        'R.attr.colorPrimary',
       );
       fs.writeFileSync(screensKt, ktData);
-      console.log('Patched react-native-screens colorPrimary reference');
+      console.log('Reverted react-native-screens colorPrimary reference');
     }
   }
 }


### PR DESCRIPTION
## Summary
- fix patch for `react-native-screens` in `update-android-sdk.js`
- document required Android SDK packages in README

## Testing
- `npm install`
- `npm run build`
- `npm install` in mobile
- `npm run android` *(fails: android directory not found)*

------
https://chatgpt.com/codex/tasks/task_e_6857d036ebc4832c82ae44ab3829fa3c