### PR TITLE
Fix screens colorPrimary patch

### DIFF
--- a/scripts/update-android-sdk.js
+++ b/scripts/update-android-sdk.js
@@ -376,13 +376,13 @@ if (fs.existsSync(nodeModulesDir)) {
   );
   if (fs.existsSync(screensKt)) {
     let ktData = fs.readFileSync(screensKt, 'utf8');
-    if (/androidx\.appcompat\.R\.attr\.colorPrimary/.test(ktData)) {
+    if (/R\.attr\.colorPrimary/.test(ktData) && !/androidx\.appcompat\.R\.attr\.colorPrimary/.test(ktData)) {
       ktData = ktData.replace(
-        /androidx\.appcompat\.R\.attr\.colorPrimary/g,
-        'R.attr.colorPrimary',
+        /R\.attr\.colorPrimary/g,
+        'androidx.appcompat.R.attr.colorPrimary',
       );
       fs.writeFileSync(screensKt, ktData);
-      console.log('Reverted react-native-screens colorPrimary reference');
+      console.log('Patched react-native-screens colorPrimary reference');
     }
   }
 }


### PR DESCRIPTION
## Summary
- adjust Android SDK update script to patch `react-native-screens` only when needed

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build` *(fails: TS2688: Cannot find type definition file for 'node')*

------
https://chatgpt.com/codex/tasks/task_e_6857d5b44194832c8923e5bfa07e6477