### PR TITLE
Fix Hermes config documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,8 +99,7 @@ cd $env:GITHUB_REPOS_DIR\amana\mobile\android
 パッチ適用後、`mobile/node_modules/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevSupportManagerBase.java` に `compatRegisterReceiver` の呼び出しが挿入されていることを確認できます。
 
 ## Hermes 関連のクラッシュ
-
-`couldn't find DSO to load: libjscexecutor.so` と表示される場合、Hermes 設定が無効になっています。次のコマンドで設定を再適用し、キャッシュを削除してからビルドし直してください。
+`couldn't find DSO to load: libjscexecutor.so` と表示される場合、Hermes 用の設定が不足しています。下記コマンドで自動修正を行い、キャッシュを削除した上で再ビルドしてください。`npm run update-android-sdk` は `mobile/android/app/build.gradle` に `project.ext.react = [ enableHermes: true ]` を追加し、`gradle.properties` の `hermesEnabled` を `true` に更新します。ファイルが無い場合は自動生成され、`ndkVersion` も推奨値に設定されます。
 
 ```powershell
 cd $env:GITHUB_REPOS_DIR\amana

--- a/scripts/update-android-sdk.js
+++ b/scripts/update-android-sdk.js
@@ -29,7 +29,7 @@ function ensureHermesBlock() {
   let gradle = fs.readFileSync(appBuildGradle, 'utf8');
   if (!/project\.ext\.react\s*=/.test(gradle)) {
     gradle = gradle.replace(
-      /apply from: ["']..\/..\/node_modules\/react-native\/react\.gradle["']/,
+      /apply from:\s*["'][^"']*react\.gradle["']/,
       (m) => `project.ext.react = [\n    enableHermes: true\n]\n${m}`,
     );
     fs.writeFileSync(appBuildGradle, gradle);
@@ -169,6 +169,9 @@ function hasKotlinAndroidPlugin(data) {
 }
 
 // Record JAVA_HOME for Gradle if possible
+if (!fs.existsSync(gradleProperties)) {
+  fs.writeFileSync(gradleProperties, '');
+}
 if (fs.existsSync(gradleProperties)) {
   const javaHome = process.env.JAVA_HOME;
   if (javaHome) {


### PR DESCRIPTION
## Summary
- create `gradle.properties` if missing in `update-android-sdk`
- document automatic creation in Hermes troubleshooting section

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6857fd3a4bc8832cb4899cbb6bf7bd4f