### PR TITLE
Improve Android setup scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,14 +41,11 @@ cd $env:GITHUB_REPOS_DIR\amana
 npm run setup-gradle
 cd $env:GITHUB_REPOS_DIR\amana
 # Android 12 以降で必要となるパッチも含む
-$env:ANDROID_PACKAGE_NAME = 'jp.kmaruoka.amana'
-npm run update-android-sdk  # 依存モジュールの BuildConfig と React Native パッチを適用
+npm run update-android-sdk  # 依存モジュールの BuildConfig と React Native パッチを適用し、gradlew clean まで実行
 # mobile の npm install 時にも自動実行されますが、
 # 新しい依存パッケージを追加した後は手動で再実行してください
-cd $env:GITHUB_REPOS_DIR\amana\mobile\android
-.\gradlew.bat clean
-# android フォルダがロックされる場合は Gradle デーモンを停止
-.\gradlew.bat --stop
+# パッケージ名は自動検出され、`DevSupportManagerBase` へのパッチと
+# `getUseDeveloperSupport()` の無効化も行われます
 cd $env:GITHUB_REPOS_DIR\amana\mobile
 npx react-native doctor
 npm run android   # または npm run ios
@@ -87,13 +84,11 @@ java.lang.RuntimeException: Requested enabled DevSupportManager, but BridgeDevSu
 Caused by: java.lang.SecurityException: One of RECEIVER_EXPORTED or RECEIVER_NOT_EXPORTED should be specified
 ```
 
-これは React Native 0.71 系の `DevSupportManagerBase.java` が Android 12 以降の仕様に対応していないためです。モバイルの `npm install` 後に自動でパッチが適用されますが、何らかの理由で適用されていない場合は次のコマンドを実行し、`./gradlew clean` を実行してからビルドし直してください。
+これは React Native 0.71 系の `DevSupportManagerBase.java` が Android 12 以降の仕様に対応していないためです。モバイルの `npm install` 後に自動でパッチが適用されますが、何らかの理由で適用されていない場合は次のコマンドを実行してください。パッケージ名は自動検出されます。
 
 ```powershell
 cd $env:GITHUB_REPOS_DIR\amana
 npm run update-android-sdk
-cd $env:GITHUB_REPOS_DIR\amana\mobile\android
-.\gradlew.bat clean
 ```
 
 パッチ適用後、`mobile/node_modules/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevSupportManagerBase.java` に `compatRegisterReceiver` の呼び出しが挿入されていることを確認できます。
@@ -106,8 +101,5 @@ cd $env:GITHUB_REPOS_DIR\amana\mobile\android
 ```powershell
 cd $env:GITHUB_REPOS_DIR\amana
 npm run update-android-sdk
-cd $env:GITHUB_REPOS_DIR\amana\mobile\android
-.\gradlew.bat clean
-cd ..
 npm run android
 ```


### PR DESCRIPTION
## Summary
- auto-detect Android package when patching mobile project
- mention automatic patching in Quick Start instructions

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68580bea14a8832c94b01973bf58a11a